### PR TITLE
Impl Deref(Mut)? for JsonString

### DIFF
--- a/crates/holochain_json_api/src/json.rs
+++ b/crates/holochain_json_api/src/json.rs
@@ -54,6 +54,22 @@ impl JsonString {
     }
 }
 
+impl Deref for JsonString {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for JsonString {
+    type Target = String;
+
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl From<bool> for JsonString {
     fn from(u: bool) -> JsonString {
         default_to_json(u)


### PR DESCRIPTION
This makes it much more ergonomic (and efficient) to pass JsonString to APIs that take an `&String` or an `&str`

Unresolved question:
Is this change at risk for making it too ergonomic such that people forget they're using a JsonString at all?

If so, I would change these to `as_str()` and `as_str_mut()` methods.