### PR TITLE
2020 06 06 serde bytes

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#! /usr/bin/env sh
 (
  cd crates/holochain_serialized_bytes && \
  cargo bench

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+(
+ cd crates/holochain_serialized_bytes && \
+ cargo bench
+)

--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -18,3 +18,14 @@ holochain_serialized_bytes_derive = { version = "=0.0.39", path = "../holochain_
 rmp-serde = "0.14.3"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"
+serde_bytes = "0.11"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "bench"
+harness = false
+
+[profile.release]
+debug = true

--- a/crates/holochain_serialized_bytes/benches/bench.rs
+++ b/crates/holochain_serialized_bytes/benches/bench.rs
@@ -36,7 +36,7 @@ pub fn round_trip_bytes(c: &mut Criterion) {
 
     macro_rules! do_it {
         ( $newtype:tt ) => {
-            for n in vec![0, 1, 1_000, 1_000_000, 1_000_000_000] {
+            for n in vec![0, 1, 1_000, 1_000_000] {
                 group.throughput(Throughput::Bytes(n as _));
                 group.sample_size(10);
                 group.bench_with_input(BenchmarkId::new(stringify!($newtype), n), &n, |b, &n| {
@@ -53,7 +53,7 @@ pub fn round_trip_bytes(c: &mut Criterion) {
         };
     };
 
-    // do_it!(GenericBytesNewType);
+    do_it!(GenericBytesNewType);
     do_it!(SpecializedBytesNewType);
 
     group.finish();

--- a/crates/holochain_serialized_bytes/benches/bench.rs
+++ b/crates/holochain_serialized_bytes/benches/bench.rs
@@ -1,0 +1,64 @@
+use criterion::BenchmarkId;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, Criterion};
+use holochain_serialized_bytes::prelude::*;
+
+#[derive(serde::Serialize, serde::Deserialize, SerializedBytes)]
+struct StringNewType(String);
+
+pub fn round_trip_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("round_trip_string");
+
+    for n in vec![0, 1, 1_000, 1_000_000] {
+        group.throughput(Throughput::Bytes(n as _));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || ".".repeat(n).to_string(),
+                |s| {
+                    StringNewType::try_from(SerializedBytes::try_from(StringNewType(s)).unwrap())
+                        .unwrap();
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+#[derive(serde::Serialize, serde::Deserialize, SerializedBytes)]
+struct GenericBytesNewType(Vec<u8>);
+#[derive(serde::Serialize, serde::Deserialize, SerializedBytes)]
+struct SpecializedBytesNewType(#[serde(with = "serde_bytes")] Vec<u8>);
+
+pub fn round_trip_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("round_trip_bytes");
+
+    macro_rules! do_it {
+        ( $newtype:tt ) => {
+            for n in vec![0, 1, 1_000, 1_000_000, 1_000_000_000] {
+                group.throughput(Throughput::Bytes(n as _));
+                group.sample_size(10);
+                group.bench_with_input(BenchmarkId::new(stringify!($newtype), n), &n, |b, &n| {
+                    b.iter_batched(
+                        || vec![0_u8; n],
+                        |s| {
+                            <$newtype>::try_from(SerializedBytes::try_from($newtype(s)).unwrap())
+                                .unwrap();
+                        },
+                        criterion::BatchSize::PerIteration,
+                    );
+                });
+            }
+        };
+    };
+
+    // do_it!(GenericBytesNewType);
+    do_it!(SpecializedBytesNewType);
+
+    group.finish();
+}
+
+criterion_group!(bench, round_trip_string, round_trip_bytes,);
+
+criterion_main!(bench);

--- a/crates/holochain_serialized_bytes/src/lib.rs
+++ b/crates/holochain_serialized_bytes/src/lib.rs
@@ -85,7 +85,7 @@ impl From<SerializedBytes> for UnsafeBytes {
 /// - round tripping data through a database that has its own serialization preferences
 /// - debug output or logging of data that is to be human readible
 /// - moving between data types within a single system that has no external facing representation
-pub struct SerializedBytes(Vec<u8>);
+pub struct SerializedBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl SerializedBytes {
     pub fn bytes(&self) -> &Vec<u8> {
@@ -340,8 +340,8 @@ pub mod tests {
                 inner: fixture_foo().try_into().unwrap()
             },
             vec![
-                129, 165, 105, 110, 110, 101, 114, 155, 204, 129, 204, 165, 105, 110, 110, 101,
-                114, 204, 163, 102, 111, 111
+                129, 165, 105, 110, 110, 101, 114, 196, 11, 129, 165, 105, 110, 110, 101, 114, 163,
+                102, 111, 111
             ]
         );
     }

--- a/crates/holochain_serialized_bytes/src/lib.rs
+++ b/crates/holochain_serialized_bytes/src/lib.rs
@@ -85,6 +85,14 @@ impl From<SerializedBytes> for UnsafeBytes {
 /// - round tripping data through a database that has its own serialization preferences
 /// - debug output or logging of data that is to be human readible
 /// - moving between data types within a single system that has no external facing representation
+///
+/// uses #[repr(transparent)] to maximise compatibility with ffi
+/// @see https://doc.rust-lang.org/1.26.2/unstable-book/language-features/repr-transparent.html#enter-reprtransparent
+///
+/// uses serde_bytes for efficient serialization and deserialization
+/// without this __every byte will be individually round tripped through serde__
+/// @see https://crates.io/crates/serde_bytes
+#[repr(transparent)]
 pub struct SerializedBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl SerializedBytes {

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,9 @@ with holonix.pkgs;
  dev-shell = stdenv.mkDerivation (holonix.shell // {
   name = "dev-shell";
 
-  buildInputs = [ ]
+  buildInputs = [
+   holonix.pkgs.gnuplot
+  ]
    ++ holonix.shell.buildInputs
 
    # main test script


### PR DESCRIPTION
this makes serialized bytes use serde_bytes which increases throughput on my machine for serialization round trips from about 20mb/s to 1-2gb/s

to test on your machine:

```
nix-shell --run ./bench.sh
```

also adds `#[repr(transparent)]` to maximise ffi compatibility with the `SerializedBytes` newtype (should help with memory sharing with wasm and plugins)

so:

- benches
- serde_bytes
- transparent repr