### PR TITLE
Update dependencies to avoiding pinning to old Rust package versions

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -66,7 +66,7 @@ hn-release-hook-version-rust-deps 'holochain_json_derive holochain_serialized_by
   # the previous version will be scanned/bumped by release scripts
   # the current version is what the release scripts bump *to*
   version = {
-   current = "0.0.46";
+   current = "0.0.47";
    # not used by version hooks in this repo
    previous = "_._._";
   };

--- a/crates/holochain_json_api/Cargo.toml
+++ b/crates/holochain_json_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_json_api"
-version = "0.0.46"
+version = "0.0.47"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 build = "build.rs"
 description = "json api and utilities for holochain"
@@ -25,7 +25,7 @@ shrinkwraprs = "=0.3.0"
 objekt = "=0.1.2"
 # keep the version on the left hand side
 # there is a regex in the release hook looking for it
-holochain_json_derive = { version = "=0.0.46", path = "../holochain_json_derive" }
+holochain_json_derive = { version = "=0.0.47", path = "../holochain_json_derive" }
 uuid = { version = "=0.7.1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/holochain_json_api/Cargo.toml
+++ b/crates/holochain_json_api/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1.0.51", features = ["preserve_order"] }
 multihash = "=0.8.0"
 futures = "=0.3.5"
 hcid = "=0.0.6"
-shrinkwraprs = "=0.2.1"
+shrinkwraprs = "=0.3.0"
 objekt = "=0.1.2"
 # keep the version on the left hand side
 # there is a regex in the release hook looking for it

--- a/crates/holochain_json_derive/Cargo.toml
+++ b/crates/holochain_json_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_json_derive"
-version = "0.0.46"
+version = "0.0.47"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 description = "Provides derive macros for holochain persistence."
 edition="2018"

--- a/crates/holochain_json_derive/Cargo.toml
+++ b/crates/holochain_json_derive/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/holochain-serialization"
 proc-macro = true
 
 [dependencies]
-syn = "=0.15.31"
-quote = "=0.6.11"
+syn = "1.0"
+quote = "1.0"
 serde = "=1.0.104"
 serde_json = { version = "1.0.51", features = ["preserve_order"] }

--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_serialized_bytes"
-version = "0.0.46"
+version = "0.0.47"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 description = "serialized bytes for holochain"
 keywords = ["holochain", "holo", "messagepack", "json", "serialization"]
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.104", features = ["serde_derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
-holochain_serialized_bytes_derive = { version = "=0.0.46", path = "../holochain_serialized_bytes_derive" }
+holochain_serialized_bytes_derive = { version = "=0.0.47", path = "../holochain_serialized_bytes_derive" }
 rmp-serde = "0.14.3"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"

--- a/crates/holochain_serialized_bytes_derive/Cargo.toml
+++ b/crates/holochain_serialized_bytes_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.46"
+version = "0.0.47"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 description = "Provides derive macros for holochain serialized bytes."
 edition="2018"

--- a/crates/holochain_serialized_bytes_derive/Cargo.toml
+++ b/crates/holochain_serialized_bytes_derive/Cargo.toml
@@ -15,5 +15,5 @@ repository = "https://github.com/holochain/holochain-serialization"
 proc-macro = true
 
 [dependencies]
-syn = "0.15.31"
-quote = "0.6.11"
+syn = "1.0"
+quote = "1.0"

--- a/test/holochain_serialized_bytes/Cargo.toml
+++ b/test/holochain_serialized_bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_holochain_serialized_bytes"
-version = "0.0.46"
+version = "0.0.47"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 description = "test serialized bytes for holochain"
 keywords = ["holochain", "holo", "messagepack", "json", "serialization"]
@@ -11,5 +11,5 @@ documentation = "https://docs.rs/holochain_serialized_bytes"
 repository = "https://github.com/holochain/holochain-serialization"
 
 [dependencies]
-holochain_serialized_bytes = { version = "=0.0.46", path = "../../crates/holochain_serialized_bytes" }
+holochain_serialized_bytes = { version = "=0.0.47", path = "../../crates/holochain_serialized_bytes" }
 serde = "=1.0.104"


### PR DESCRIPTION
o Specify a "1.0" version for syn and quote, to allow upstream packages
  to specify newer versions; major/minor version compatibility should
  be sufficiently stable.
o Update shrinkwraprs to not pin an old syn version.

