### PR TITLE
 TK-07472 tracing on encode and decode

### DIFF
--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -19,10 +19,11 @@ rmp-serde = "0.14.3"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"
 serde_bytes = "0.11"
-tracing = { version = "0.1.22", optional = true }
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+tracing-subscriber="0.2"
 
 [[bench]]
 name = "bench"
@@ -32,4 +33,4 @@ harness = false
 debug = true
 
 [features]
-trace-errors = ["tracing"]
+trace = ["tracing"]

--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -19,6 +19,7 @@ rmp-serde = "0.14.3"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"
 serde_bytes = "0.11"
+tracing = { version = "0.1.22", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -29,3 +30,6 @@ harness = false
 
 [profile.release]
 debug = true
+
+[features]
+trace-errors = ["tracing"]

--- a/crates/holochain_serialized_bytes/src/lib.rs
+++ b/crates/holochain_serialized_bytes/src/lib.rs
@@ -31,7 +31,16 @@ where
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, thiserror::Error,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    thiserror::Error,
 )]
 pub enum SerializedBytesError {
     /// somehow failed to move to bytes
@@ -39,7 +48,7 @@ pub enum SerializedBytesError {
     Serialize(String, String),
     /// somehow failed to restore bytes
     /// i mean, this could be anything, how do i know what's wrong with your bytes?
-    Deserialize(String, Vec<u8>),
+    Deserialize(String, #[serde(with = "serde_bytes")] Vec<u8>),
 }
 
 impl SerializedBytesError {
@@ -349,8 +358,11 @@ pub mod tests {
         match error {
             Err(e) => {
                 assert_eq!(e.as_undeserializable().to_vec(), bad_bytes);
-                assert_eq!(e.as_serde_error(), "invalid type: integer `1`, expected a string");
-            },
+                assert_eq!(
+                    e.as_serde_error(),
+                    "invalid type: integer `1`, expected a string"
+                );
+            }
             _ => unreachable!(),
         }
     }

--- a/crates/holochain_serialized_bytes/src/prelude.rs
+++ b/crates/holochain_serialized_bytes/src/prelude.rs
@@ -11,3 +11,6 @@ pub use crate::SerializedBytes;
 pub use crate::SerializedBytesError;
 pub use crate::UnsafeBytes;
 pub use holochain_serialized_bytes_derive::SerializedBytes;
+
+pub use crate::decode;
+pub use crate::encode;

--- a/test/default.nix
+++ b/test/default.nix
@@ -8,6 +8,11 @@ let
   hn-rust-fmt-check \
   && hn-rust-clippy \
   && cargo test
+
+  RUST_LOG=trace cargo test \
+    --manifest-path="crates/holochain_serialized_bytes/Cargo.toml" \
+    --features="trace" \
+    -- --nocapture
   '';
 in
 {

--- a/test/default.nix
+++ b/test/default.nix
@@ -9,7 +9,7 @@ let
   && hn-rust-clippy \
   && cargo test
 
-  RUST_LOG=trace cargo test \
+  cargo test \
     --manifest-path="crates/holochain_serialized_bytes/Cargo.toml" \
     --features="trace" \
     -- --nocapture


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/629710/106317178-5ae50e80-6287-11eb-80ae-445e6389dcb0.png)


- adds the requirement of `std::fmt::Debug` on `encode` and `decode` input and output so we can trace it
- instruments and warns on bad encoding and decoding and traces good encoding and decoding
- rename `ToBytes` and `FromBytes` to `Serialize` and `Deserialze`
- add `encode` and `decode` to the prelude
- puts the tracing behind a `trace` feature flag so it is removed by default e.g. to keep wasm slim