### PR TITLE
Arbitrary impl for SerializedBytes

### DIFF
--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -21,6 +21,8 @@ thiserror = "1.0.10"
 serde_bytes = "0.11"
 tracing = { version = "0.1", optional = true }
 
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
+
 [dev-dependencies]
 criterion = "0.3"
 tracing-subscriber="0.2"

--- a/crates/holochain_serialized_bytes/src/lib.rs
+++ b/crates/holochain_serialized_bytes/src/lib.rs
@@ -176,9 +176,12 @@ impl std::fmt::Debug for SerializedBytes {
         let mut deserializer = rmp_serde::Deserializer::from_read_ref(&self.0);
         let writer = Vec::new();
         let mut serializer = serde_json::ser::Serializer::new(writer);
-        serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
-        let s = unsafe { String::from_utf8_unchecked(serializer.into_inner()) };
-        write!(f, "{}", s)
+        if let Err(_) = serde_transcode::transcode(&mut deserializer, &mut serializer) {
+            write!(f, "<invalid msgpack>")
+        } else {
+            let s = unsafe { String::from_utf8_unchecked(serializer.into_inner()) };
+            write!(f, "{}", s)
+        }
     }
 }
 

--- a/crates/holochain_serialized_bytes/src/lib.rs
+++ b/crates/holochain_serialized_bytes/src/lib.rs
@@ -94,6 +94,7 @@ impl From<Infallible> for SerializedBytesError {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// UnsafeBytes the only way to implement a custom round trip through bytes for SerializedBytes
 /// It is intended to be an internal implementation in TryFrom implementations
 /// The assumption is that any code using UnsafeBytes is NOT valid messagepack data
@@ -151,6 +152,7 @@ impl From<SerializedBytes> for UnsafeBytes {
 /// without this __every byte will be individually round tripped through serde__
 /// @see https://crates.io/crates/serde_bytes
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(transparent)]
 pub struct SerializedBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 


### PR DESCRIPTION
The crate is put behind a feature so that it won't impact crates that don't use the feature.

Also removes the hard requirement that SerializedBytes be msgpack-encodable, to allow truly arbitrary SerializedBytes (including invalid ones)