### PR TITLE
test: add conductor api serialization guard

### DIFF
--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/holochain/holochain-serialization"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.123", features = ["serde_derive"] }
+serde = { version = "1.0.181", features = ["serde_derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 holochain_serialized_bytes_derive = { version = "=0.0.53", path = "../holochain_serialized_bytes_derive" }
 rmp-serde = "0.15"


### PR DESCRIPTION
Recently the Conductor API broke without our knowledge because of a [change in a serde patch version](https://github.com/serde-rs/serde/pull/2505) from 1.0.180 to 1.0.181. I've added smoke tests to the serialization of App and Admin API in the Holochain repo and want to add a similar test to this repo too.

There's no Cargo lock in this repo and it specifies serde at minimum version 1.0.123. When used in the Holochain repo, serde is effectively above 1.0.181, so that's what I want to set the minimum version to in this repo.

Let me know what you think about the JSON part of the test especially.