### PR TITLE
build(rmp-serde): pin to v0.15.5

### DIFF
--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 serde = { version = "=1.0.193", features = ["serde_derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 holochain_serialized_bytes_derive = { version = "=0.0.53", path = "../holochain_serialized_bytes_derive" }
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"
 serde_bytes = "0.11"


### PR DESCRIPTION
I tried to update to v1 but the refactor would require a little time which I don't want to spend now. So just the pin to v0.15.5