### PR TITLE
build!: update rmp serde to v1

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,6 @@ jobs:
       - name: Build Nix packages for dev shell
         run: nix develop -c $SHELL -c "rustc --version --verbose"
       - name: Run fmt
-        run: nix develop -c $SHELL -c "script-holochain-tests-static-fmt"
+        run: nix develop -c cargo fmt --all -- --check
       - name: Run clippy
-        run: nix develop -c $SHELL -c "script-holochain-tests-static-clippy"
+        run: nix develop -c cargo clippy --all -- --deny warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+## Changed
+- **BREAKING**: Updated dependencies `rmp-serde` and `serde`. Serialization format for Rust enums changed.
+An enum
+```rust
+enum ConductorApi {
+    Request { param: i32 },
+}
+let request = ConductorApi::Request { param: 100 };
+```
+previously serialized to
+```json
+{
+    "type": {
+        "request": null
+    },
+    "data": {
+        "param": 100
+    }
+}
+```
+and now serializes to
+```json
+{
+    "type": "request",
+    "data": {
+        "param": 100
+    }
+}
+```
+
 ## [0.0.53] - 2023-08-29
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,10 @@ members = [
 
 [profile.release]
 debug = true
+
+[workspace.lints.clippy]
+style = "deny"
+complexity = "deny"
+perf = "deny"
+correctness = "deny"
+dbg_macro = "deny"

--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -38,3 +38,6 @@ harness = false
 fuzzing = ["arbitrary", "proptest", "proptest-derive"]
 
 trace = ["tracing"]
+
+[lints]
+workspace = true

--- a/crates/holochain_serialized_bytes/Cargo.toml
+++ b/crates/holochain_serialized_bytes/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/holochain/holochain-serialization"
 edition = "2018"
 
 [dependencies]
-serde = { version = "=1.0.193", features = ["serde_derive"] }
+serde = { version = "=1.0.197", features = ["serde_derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 holochain_serialized_bytes_derive = { version = "=0.0.53", path = "../holochain_serialized_bytes_derive" }
-rmp-serde = "=0.15.5"
+rmp-serde = "=1.1.2"
 serde-transcode = "1.1.0"
 thiserror = "1.0.10"
 serde_bytes = "0.11"
@@ -27,7 +27,7 @@ proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-tracing-subscriber="0.2"
+tracing-subscriber = "0.2"
 test-fuzz = "=3.0.4"
 
 [[bench]]
@@ -35,10 +35,6 @@ name = "bench"
 harness = false
 
 [features]
-fuzzing = [
-    "arbitrary",
-    "proptest",
-    "proptest-derive",
-]
+fuzzing = ["arbitrary", "proptest", "proptest-derive"]
 
 trace = ["tracing"]

--- a/crates/holochain_serialized_bytes_derive/Cargo.toml
+++ b/crates/holochain_serialized_bytes_derive/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+
+[lints]
+workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -141,16 +141,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1712161287,
-        "narHash": "sha256-izcly9+JWv15F70SK5DcyZyuMomO4+HmvoQ0CWh3J3M=",
+        "lastModified": 1712710944,
+        "narHash": "sha256-ye4bu3XgmufPZWwd2RCBkdkyV9dCVAx4CLiL8QKgixg=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a87b7b6280bd913d7ac88841810d2013864c0959",
+        "rev": "28dce06eef726cc7320637ab76ffe6f2798b12b8",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.0-beta-dev.44",
+        "ref": "holochain-0.3.0-beta-dev.45",
         "repo": "holochain",
         "type": "github"
       }
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712786128,
-        "narHash": "sha256-uxpNpl9EvOTBgBWkz0ZbTNLH8AHT/Vb4Y33hQ9yJ3zU=",
+        "lastModified": 1713337081,
+        "narHash": "sha256-8KpJN5wXFY/6OF30EVbWBom9nulOS2BOH5HevAQ+feM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "5d94e128e4d23e7848466af0eaeb73ff8158e5aa",
+        "rev": "99a6345b2672cb6cfae92e4b85e763ecd0dcade7",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712608508,
-        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712715149,
-        "narHash": "sha256-uOx7GaLV+5hekAYtm/CBr627Pi7+d1Yh70hwKmVjYYo=",
+        "lastModified": 1713320003,
+        "narHash": "sha256-HY8uzaDMzn6umca2kE4ce5BEujaw+gvEiC5xTwAHSC4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9ef1eca23bee5fb8080863909af3802130b2ee57",
+        "rev": "7ce479797ae35ab40fbdf04fe5a8f8bfc92a2634",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1712589090,
-        "narHash": "sha256-neMBujjSEsOI0/MT1JpYnjtMq4tKHloCbYd8w6ARAKQ=",
+        "lastModified": 1712841191,
+        "narHash": "sha256-96bq4Yo50p8Nu1CmsnmEOjGDHM8+ak8x+7mZ7vFtZHo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "55b17239fb7aa80d6afce24479bb2b7ef18c5b6b",
+        "rev": "63a2c7966c21abff1c0397fbf4fde7329d0092cd",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1712786128,
-        "narHash": "sha256-uxpNpl9EvOTBgBWkz0ZbTNLH8AHT/Vb4Y33hQ9yJ3zU=",
+        "lastModified": 1713337081,
+        "narHash": "sha256-8KpJN5wXFY/6OF30EVbWBom9nulOS2BOH5HevAQ+feM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "5d94e128e4d23e7848466af0eaeb73ff8158e5aa",
+        "rev": "99a6345b2672cb6cfae92e4b85e763ecd0dcade7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cargo-chef": {
       "flake": false,
       "locked": {
-        "lastModified": 1672901199,
-        "narHash": "sha256-MHTuR4aQ1rQaBKx1vWDy2wbvcT0ZAzpkVB2zylSC+k0=",
+        "lastModified": 1695999026,
+        "narHash": "sha256-UtLoZd7YBRSF9uXStfC3geEFqSqZXFh1rLHaP8hre0Y=",
         "owner": "LukeMathWalker",
         "repo": "cargo-chef",
-        "rev": "5c9f11578a2e0783cce27666737d50f84510b8b5",
+        "rev": "6e96ae5cd023b718ae40d608981e50a6e7d7facf",
         "type": "github"
       },
       "original": {
@@ -36,20 +36,17 @@
     },
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "holonix",
           "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay"
+        ]
       },
       "locked": {
-        "lastModified": 1675475924,
-        "narHash": "sha256-KWdfV9a6+zG6Ij/7PZYLnomjBZZUu8gdRy+hfjGrrJQ=",
+        "lastModified": 1707363936,
+        "narHash": "sha256-QbqyvGFYt84QNOQLOOTWplZZkzkyDhYrAl/N/9H0vFM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1bde9c762ebf26de9f8ecf502357c92105bc4577",
+        "rev": "9107434eda6991e9388ad87b815dafa337446d16",
         "type": "github"
       },
       "original": {
@@ -61,11 +58,11 @@
     "crate2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1693149153,
-        "narHash": "sha256-HUszQcnIal1FFRAWraODDbxTp0HECwczRTD+Zf0v9o0=",
+        "lastModified": 1706909251,
+        "narHash": "sha256-T7G9Uhh77P0kKri/u+Mwa/4YnXwdPsJSwYCiJCCW+fs=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "8749f46953b46d44fd181b002399e4a20371f323",
+        "rev": "15656bb6cb15f55ee3344bf4362e6489feb93db6",
         "type": "github"
       },
       "original": {
@@ -93,27 +90,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -127,11 +108,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1675295133,
-        "narHash": "sha256-dU8fuLL98WFXG0VnRgM00bqKX6CEPBLybhiIDIgO45o=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bf53492df08f3178ce85e0c9df8ed8d03c030c9f",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -140,30 +121,15 @@
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -175,16 +141,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1700008501,
-        "narHash": "sha256-dfktlBmLf6vea5lCxFCFSD56xwdIesaGsBE3Krzt1l4=",
+        "lastModified": 1712161287,
+        "narHash": "sha256-izcly9+JWv15F70SK5DcyZyuMomO4+HmvoQ0CWh3J3M=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "6507dc5c874e9148cbd08cd0356031fe28066a8d",
+        "rev": "a87b7b6280bd913d7ac88841810d2013864c0959",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.0-beta-dev.24",
+        "ref": "holochain-0.3.0-beta-dev.44",
         "repo": "holochain",
         "type": "github"
       }
@@ -196,7 +162,7 @@
         "crane": "crane",
         "crate2nix": "crate2nix",
         "empty": "empty",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "holochain": [
           "holonix",
@@ -214,7 +180,7 @@
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "repo-git": "repo-git",
-        "rust-overlay": "rust-overlay_2",
+        "rust-overlay": "rust-overlay",
         "scaffolding": [
           "holonix",
           "empty"
@@ -224,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700609794,
-        "narHash": "sha256-ucEV/uaVNDP4c6t3oi5GmHZThTxVSQeBiSHelwh7Ce8=",
+        "lastModified": 1712786128,
+        "narHash": "sha256-uxpNpl9EvOTBgBWkz0ZbTNLH8AHT/Vb4Y33hQ9yJ3zU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d8ac8141864965481fc64db1bfa5b1902caae6fe",
+        "rev": "5d94e128e4d23e7848466af0eaeb73ff8158e5aa",
         "type": "github"
       },
       "original": {
@@ -240,16 +206,16 @@
     "lair": {
       "flake": false,
       "locked": {
-        "lastModified": 1691746070,
-        "narHash": "sha256-CHsTI4yIlkfnYWx2sNgzAoDBvKTLIChybzyJNbB1sMU=",
+        "lastModified": 1709335027,
+        "narHash": "sha256-rKMhh7TLuR1lqze2YFWZCGYKZQoB4dZxjpX3sb7r7Jk=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "6ab41b60744515f1760669db6fc5272298a5f324",
+        "rev": "826be915efc839d1d1b8a2156b158999b8de8d5b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.3.0",
+        "ref": "lair_keystore-v0.4.4",
         "repo": "lair",
         "type": "github"
       }
@@ -257,11 +223,11 @@
     "launcher": {
       "flake": false,
       "locked": {
-        "lastModified": 1696872398,
-        "narHash": "sha256-wRFBUxweljJShXNEZlZGUKScBPVQm6ydH1QFvoNlbIE=",
+        "lastModified": 1712599324,
+        "narHash": "sha256-MNUTplS5O+w1G70kZMpFGfBTqOzzTRU6DYarl1bGVFY=",
         "owner": "holochain",
         "repo": "launcher",
-        "rev": "1beda27221504085ae1dd537788433bee9c6f353",
+        "rev": "597592253c9d2ca64a4e4ac4675ff5081c9dd9b5",
         "type": "github"
       },
       "original": {
@@ -273,11 +239,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1675361037,
-        "narHash": "sha256-CTbDuDxFD3U3g/dWUB+r+B/snIe+qqP1R+1myuFGe2I=",
+        "lastModified": 1705332318,
+        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "e1b2f96c2a31415f362268bc48c3fccf47dff6eb",
+        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
         "type": "github"
       },
       "original": {
@@ -288,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700390070,
-        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
+        "lastModified": 1712608508,
+        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
+        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
         "type": "github"
       },
       "original": {
@@ -304,11 +270,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1675183161,
-        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {
@@ -322,11 +288,11 @@
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1676513100,
-        "narHash": "sha256-MK39nQV86L2ag4TmcK5/+r1ULpzRLPbbfvWbPvIoYJE=",
+        "lastModified": 1707297608,
+        "narHash": "sha256-ADjo/5VySGlvtCW3qR+vdFF4xM9kJFlRDqcC9ZGI8EA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5f0cba88ac4d6dd8cad5c6f6f1540b3d6a21a798",
+        "rev": "0db2e67ee49910adfa13010e7f012149660af7f0",
         "type": "github"
       },
       "original": {
@@ -359,45 +325,18 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "holonix",
-          "crane",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "holonix",
-          "crane",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1675391458,
-        "narHash": "sha256-ukDKZw922BnK5ohL9LhwtaDAdCsJL7L6ScNEyF1lO9w=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "383a4acfd11d778d5c2efcf28376cbd845eeaedf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "holonix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1700533079,
-        "narHash": "sha256-K/8s5LXVQquJWrMcM7NG70o/S5Bxm2D64on5qju3tQY=",
+        "lastModified": 1712715149,
+        "narHash": "sha256-uOx7GaLV+5hekAYtm/CBr627Pi7+d1Yh70hwKmVjYYo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6da9555a6d691bcdf43f90d8fd445e96d246f807",
+        "rev": "9ef1eca23bee5fb8080863909af3802130b2ee57",
         "type": "github"
       },
       "original": {
@@ -409,16 +348,16 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1695674679,
-        "narHash": "sha256-IwgQbgitUo61ZXYSXBAro5ThfYy/yMGmzZGTb3c6sT0=",
+        "lastModified": 1712589090,
+        "narHash": "sha256-neMBujjSEsOI0/MT1JpYnjtMq4tKHloCbYd8w6ARAKQ=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "821439b8dd49d5ce594be04c4720df25e88a4dbc",
+        "rev": "55b17239fb7aa80d6afce24479bb2b7ef18c5b6b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.2",
+        "ref": "holochain-weekly",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -447,11 +386,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1700609794,
-        "narHash": "sha256-ucEV/uaVNDP4c6t3oi5GmHZThTxVSQeBiSHelwh7Ce8=",
+        "lastModified": 1712786128,
+        "narHash": "sha256-uxpNpl9EvOTBgBWkz0ZbTNLH8AHT/Vb4Y33hQ9yJ3zU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d8ac8141864965481fc64db1bfa5b1902caae6fe",
+        "rev": "5d94e128e4d23e7848466af0eaeb73ff8158e5aa",
         "type": "github"
       },
       "original": {

--- a/test/holochain_serialized_bytes/Cargo.toml
+++ b/test/holochain_serialized_bytes/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/holochain/holochain-serialization"
 
 [dependencies]
 holochain_serialized_bytes = { version = "=0.0.53", path = "../../crates/holochain_serialized_bytes" }
-serde = "=1.0.193"
+serde = "=1.0.197"
 
 [dev-dependencies]
 test-fuzz = "=3.0.4"


### PR DESCRIPTION
rmp-serde is pinned to v0.15.5 and in conjunction with serde produces an unusual serialization for enums, e. g.

An enum in Rust
```rust
#[serde(tag = "type", content = "content")]
pub enum Authority {
    Agent(AgentPubKey),
}
```
serializes to
```jost
{
    "type": {
        "agent": null
    },
    "content": "uhCAkRNQ78aF5GvtY3dL4sLR66Xq_VeancOXV79iosN-hZdQ27BwU"
}
```
instead of
```jost
{
    "type": "agent",
    "content": "uhCAkRNQ78aF5GvtY3dL4sLR66Xq_VeancOXV79iosN-hZdQ27BwU"
}
```

part of https://github.com/holochain/holochain/issues/3598